### PR TITLE
Add stats page

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -19,6 +19,7 @@ package com.google.codeu.data;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.FilterOperator;
@@ -78,5 +79,12 @@ public class Datastore {
     }
 
     return messages;
+  }
+
+  /** Returns the total number of messages for all users. */
+  public int getTotalMessageCount(){
+    Query query = new Query("Message");
+    PreparedQuery results = datastore.prepare(query);
+    return results.countEntities(FetchOptions.Builder.withLimit(1000));
   }
 }

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -7,16 +7,33 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.codeu.data.Datastore;
+import com.google.gson.JsonObject;
+
 /**
- * Responds with a hard-coded message for testing purposes.
+ * Handles fetching site statistics.
  */
 @WebServlet("/stats")
 public class StatsPageServlet extends HttpServlet {
 
-    @Override
-    public void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws IOException {
+    private Datastore datastore;
 
-        response.getOutputStream().println("hello world");
+    @Override
+    public void init() {
+        datastore = new Datastore();
+    }
+
+    /**
+     * Responds with site statistics in JSON.
+     */
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("application/json");
+
+        int messageCount = datastore.getTotalMessageCount();
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("messageCount", messageCount);
+        response.getOutputStream().println(jsonObject.toString());
     }
 }

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -1,0 +1,22 @@
+package com.google.codeu.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Responds with a hard-coded message for testing purposes.
+ */
+@WebServlet("/stats")
+public class StatsPageServlet extends HttpServlet {
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+
+        response.getOutputStream().println("hello world");
+    }
+}

--- a/src/main/webapp/aboutus.html
+++ b/src/main/webapp/aboutus.html
@@ -25,6 +25,7 @@ limitations under the License.
     <nav>
       <ul id="navigation">
         <li><a href="/">Home</a></li>
+        <li><a href="/stats.html">Statistics</a></li>
         <li><a href="/aboutus.html">About Our Team</a></li>
       </ul>
     </nav>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -26,6 +26,7 @@ limitations under the License.
     <nav>
       <ul id="navigation">
         <li><a href="/">Home</a></li>
+        <li><a href="/stats.html">Statistics</a></li>
         <li><a href="/aboutus.html">About Our Team</a></li>
       </ul>
     </nav>

--- a/src/main/webapp/js/stats-page-loader.js
+++ b/src/main/webapp/js/stats-page-loader.js
@@ -1,0 +1,24 @@
+// Fetch stats and display them in the page.
+function fetchStats() {
+    const url = '/stats';
+    fetch(url).then((response) => {
+        return response.json();
+    }).then((stats) => {
+        const statsContainer = document.getElementById('stats-container');
+        statsContainer.innerHTML = '';
+
+        const messageCountElement = buildStatElement('Message count: ' + stats.messageCount);
+        statsContainer.appendChild(messageCountElement);
+    });
+}
+
+function buildStatElement(statString) {
+    const statElement = document.createElement('p');
+    statElement.appendChild(document.createTextNode(statString));
+    return statElement;
+}
+
+// Fetch data and populate the UI of the page.
+function buildUI() {
+    fetchStats();
+}

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -6,6 +6,13 @@
     <script src="/js/stats-page-loader.js"></script>
 </head>
 <body onload="buildUI()">
+<nav>
+    <ul id="navigation">
+        <li><a href="/">Home</a></li>
+        <li><a href="/stats.html">Statistics</a></li>
+        <li><a href="/aboutus.html">About Our Team</a></li>
+    </ul>
+</nav>
 <div id="content">
     <h1>Site Statistics</h1>
     <hr/>

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Stats</title>
+    <link rel="stylesheet" href="/css/main.css">
+    <script src="/js/stats-page-loader.js"></script>
+</head>
+<body onload="buildUI()">
+<div id="content">
+    <h1>Site Statistics</h1>
+    <hr/>
+    <div id="stats-container">Loading...</div>
+</div>
+</body>
+</html>

--- a/src/main/webapp/user-page.html
+++ b/src/main/webapp/user-page.html
@@ -27,6 +27,7 @@ limitations under the License.
     <nav>
       <ul id="navigation">
         <li><a href="/">Home</a></li>
+        <li><a href="/stats.html">Statistics</a></li>
         <li><a href="/aboutus.html">About Our Team</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
Displays total number of messages from all users at the `/stats` endpoint.
- `StatsPageServlet.java`: Processes the HTTP request and returns a JSON response after querying the datastore
- `stats.html`: HTML page that displays the stats
- `stats-page-loader.js`: JS script that populates data to be displayed in `stats.html`