### PR TITLE
Make image labels in search container more clickable

### DIFF
--- a/src/main/webapp/js/feed-page-loader.js
+++ b/src/main/webapp/js/feed-page-loader.js
@@ -6,8 +6,11 @@ function fetchImageLabels() {
     parameterImageLabels.forEach((parameterImageLabel) => {
       const searchTagContainer = document.getElementById('search-tag-container');
       const imageLabelButton = document.createElement('div');
+      const uriEncodedParameterImageLabel = encodeURIComponent(parameterImageLabel);
       imageLabelButton.innerHTML = `<button type="button" class="btn btn-info btn-sm mr-2 mb-2 pr-1 imageLabelButton">
-                                      <span class="mr-1">${parameterImageLabel}</span>  <span onClick="onClickImageLabelCancelButton('${parameterImageLabel}')">&times;</span>
+                                      <span class="mr-1">${parameterImageLabel}</span>  <span onClick="onClickImageLabelCancelButton('${uriEncodedParameterImageLabel}')">
+                                        <i class="fas fa-times-circle"></i>
+                                      </span>
                                     </button>`;
       searchTagContainer.appendChild(imageLabelButton);
     });


### PR DESCRIPTION
1. Add a more prominent icon so users can click to delete the image
label for search more easily.
2. Encode the parameter image label so that cancel works even when
there are spaces in the label