### PR TITLE
Fix bug in getUserProfileUrl

### DIFF
--- a/src/main/webapp/js/message-loader.js
+++ b/src/main/webapp/js/message-loader.js
@@ -454,7 +454,7 @@ function enablePostButton(commentInputTextArea, messageId) {
 
 function getUserProfileUrl(email) {
   if (email === null || email === undefined || email === '') {
-    return './images/default-user-profile/1.jpg';
+    return Promise.resolve('./images/default-user-profile/1.jpg');
   }
 
   const url = `/user-profile?user=${email}`;


### PR DESCRIPTION
This fixes the following error: feed page fails to load messages when user is not logged in.